### PR TITLE
fixed 32-bit incompability

### DIFF
--- a/rust-portaudio-sys/src/lib.rs
+++ b/rust-portaudio-sys/src/lib.rs
@@ -18,7 +18,7 @@ pub use portaudio::*;
 pub const PA_NO_DEVICE : PaDeviceIndex = -1;
 
 // Sample format
-pub type SampleFormat = u64;
+pub type SampleFormat = ::std::os::raw::c_ulong;
 pub const PA_FLOAT_32        : SampleFormat = 0x00000001;
 pub const PA_INT_32          : SampleFormat = 0x00000002;
 pub const PA_INT_24          : SampleFormat = 0x00000004;
@@ -29,7 +29,7 @@ pub const PA_CUSTOM_FORMAT   : SampleFormat = 0x00010000;
 pub const PA_NON_INTERLEAVED : SampleFormat = 0x80000000;
 
 // Stream flags
-pub type StreamFlags = u64;
+pub type StreamFlags = ::std::os::raw::c_ulong;
 pub const PA_NO_FLAG                                    : StreamFlags = 0;
 pub const PA_CLIP_OFF                                   : StreamFlags = 0x00000001;
 pub const PA_DITHER_OFF                                 : StreamFlags = 0x00000002;
@@ -38,7 +38,7 @@ pub const PA_PRIME_OUTPUT_BUFFERS_USING_STREAM_CALLBACK : StreamFlags = 0x000000
 pub const PA_PLATFORM_SPECIFIC_FLAGS                    : StreamFlags = 0xFFFF0000;
 
 // Stream callback falgs.
-pub type StreamCallbackFlags = u64;
+pub type StreamCallbackFlags = ::std::os::raw::c_ulong;
 pub const INPUT_UNDERFLOW  : StreamCallbackFlags = 0x00000001;
 pub const INPUT_OVERFLOW   : StreamCallbackFlags = 0x00000002;
 pub const OUTPUT_UNDERFLOW : StreamCallbackFlags = 0x00000004;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -676,7 +676,7 @@ pub mod flags {
         ///
         /// See the [bitflags repo](https://github.com/rust-lang/bitflags/blob/master/src/lib.rs)
         /// for examples of composing flags together.
-        pub flags Flags: u64 {
+        pub flags Flags: ::std::os::raw::c_ulong {
             /// No flags.
             const NO_FLAG =                                       ffi::PA_NO_FLAG,
             /// Disable default clipping of out of range samples.
@@ -714,7 +714,7 @@ pub mod flags {
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum Available {
     /// The number of frames available for reading.
-    Frames(i64),
+    Frames(::std::os::raw::c_long),
     /// The input stream has overflowed.
     InputOverflowed,
     /// The output stream has underflowed.
@@ -726,7 +726,7 @@ pub mod callback_flags {
     use ffi;
     bitflags! {
         /// Flag bit constants for the status flags passed to the stream's callback function.
-        pub flags CallbackFlags: u64 {
+        pub flags CallbackFlags:  ::std::os::raw::c_ulong {
             /// No flags.
             const NO_FLAG          = ffi::PA_NO_FLAG,
             /// In a stream opened with paFramesPerBufferUnspecified, indicates that input data is
@@ -1192,7 +1192,7 @@ impl<F> Stream<Blocking<F::Buffer>, F>
     pub fn read_available(&self) -> Result<Available, Error> {
         match unsafe { ffi::Pa_GetStreamReadAvailable(self.pa_stream) } {
             n if n >= 0 => Ok(Available::Frames(n)),
-            n           => match FromPrimitive::from_i64(n) {
+            n           => match FromPrimitive::from_i64(n as i64) {
                 Some(Error::InputOverflowed) => Ok(Available::InputOverflowed),
                 Some(Error::OutputUnderflowed) => Ok(Available::OutputUnderflowed),
                 Some(err) => Err(err),
@@ -1249,7 +1249,7 @@ impl<F> Stream<Blocking<F::Buffer>, F>
     pub fn write_available(&self) -> Result<Available, Error> {
         match unsafe { ffi::Pa_GetStreamWriteAvailable(self.pa_stream) } {
             n if n >= 0 => Ok(Available::Frames(n)),
-            n           => match FromPrimitive::from_i64(n) {
+            n           => match FromPrimitive::from_i64(n as i64) {
                 Some(Error::InputOverflowed) => Ok(Available::InputOverflowed),
                 Some(Error::OutputUnderflowed) => Ok(Available::OutputUnderflowed),
                 Some(err) => Err(err),

--- a/src/types.rs
+++ b/src/types.rs
@@ -202,7 +202,7 @@ pub mod sample_format_flags {
         /// The paNonInterleaved flag indicates that audio data is passed as an array of pointers
         /// to separate buffers, one buffer for each channel. Usually, when this flag is not used,
         /// audio data is passed as a single buffer with all channels interleaved.
-        pub flags SampleFormatFlags: u64 {
+        pub flags SampleFormatFlags: ::std::os::raw::c_ulong {
             /// 32 bits float sample format
             const FLOAT_32 = ffi::PA_FLOAT_32,
             /// 32 bits int sample format


### PR DESCRIPTION
The crate did not compile on my raspberry pi due to the fact that it has a 32-bit processor.
This changes did fix that issue. The crate does still compile and work fine on my 64-bit mac as well.